### PR TITLE
Add parsing of 3D information for IC6K

### DIFF
--- a/microf/__main__.py
+++ b/microf/__main__.py
@@ -209,6 +209,12 @@ class IC6kToCV7k(Action):
             new_md['well_letter'] = old_md['well_letter']
             new_md['well_nr'] = int(old_md['well_nr'])
             new_md['site'] = int(old_md['site'])
+            # If the IC6K filename contains a Z position, use it
+            if old_md['z_pos']:
+                new_md['zslice'] = int(old_md['z_pos'])
+            # If there is no z position in the filename, default to 1
+            else:
+                new_md['zslice'] = 1
             new_md['channel'] = self._ic6000_channels[old_md['channel_tag']]
         except Exception as err:
             raise RuntimeError(
@@ -221,7 +227,7 @@ class IC6kToCV7k(Action):
             new_md
         )
 
-    _cv7000_fmt = '{experiment_name}_{well_letter}{well_nr:02d}_T0001F{site:03d}L01A01Z01C{channel:02d}.tif'
+    _cv7000_fmt = '{experiment_name}_{well_letter}{well_nr:02d}_T0001F{site:03d}L01A01Z{zslice:02d}C{channel:02d}.tif'
 
     # FIXME: this pattern seems specific to the current configuration
     # of the IC6000 at PelkmansLab
@@ -236,7 +242,8 @@ class IC6kToCV7k(Action):
             r'(?P<well_letter>[A-Z]+) - (?P<well_nr>[0-9]+)'
             r'\('
             r'fld (?P<site>[0-9]+)'
-            r' wv (?P<channel_color>[A-Za-z]+) - (?P<channel_tag>.+)'
+            r' wv (?P<channel_color>[A-Za-z]+) - (?P<channel_tag>\w*)'
+            r'( z (?P<z_pos>\d*))*'
             r'\)'
             r'\.'
         ),

--- a/microf/__main__.py
+++ b/microf/__main__.py
@@ -210,7 +210,7 @@ class IC6kToCV7k(Action):
             new_md['well_nr'] = int(old_md['well_nr'])
             new_md['site'] = int(old_md['site'])
             # If the IC6K filename contains a Z position, use it
-            if old_md['z_pos']:
+            if old_md['z_pos'] is not None:
                 new_md['zslice'] = int(old_md['z_pos'])
             # If there is no z position in the filename, default to 1
             else:
@@ -243,7 +243,7 @@ class IC6kToCV7k(Action):
             r'\('
             r'fld (?P<site>[0-9]+)'
             r' wv (?P<channel_color>[A-Za-z]+) - (?P<channel_tag>\w*)'
-            r'( z (?P<z_pos>\d*))*'
+            r'( z (?P<z_pos>\d+))?'
             r'\)'
             r'\.'
         ),


### PR DESCRIPTION
@riccardomurri 
I added functionality to the mf filename conversion from IC6K to CV7K, such that it also parses 3D information if available and behaves like before if it is not. I tested it locally in python and it parses both filenames with and without Z information correctly. E.g.:
No Z: '20180328_TestAbs_G - 8(fld 4 wv Red - Cy5).tif'
With Z: '20181012_bDNAFISH4_C - 7(fld 18 wv Blue - FITC z 9).tif'
I haven't figure out yet how to install mf locally, so that I could also test it through the command line. But nothing should be changed in the command line, as it only changes the regex & file name formatting in the IC6kToCV7k class.
Can you review this and let me know if anything else is required for this to be updated on the cluster? I would like to use this updated version afterwards on the cluster to process some new files I have.